### PR TITLE
Add async support for hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 1.9.1 - 2024-01-23
 ### Added
-- Types for assertions, core func.
 - Added async support for hooks:
   - `beforeAll( async() => {})`
   - `afterAll( async() => {})`
   - `beforeEach( async() => {})`
   - `afterEach( async() => {})`
+
+## 1.9.1 - 2024-01-23
+### Added
+- Types for assertions, core func.
 
 ### Fixed
 - Fixed assertions https://github.com/VadimNastoyashchy/real-test-js/issues/74

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Types for assertions, core func.
+- Added async support for hooks:
+  - `beforeAll( async() => {})`
+  - `afterAll( async() => {})`
+  - `beforeEach( async() => {})`
+  - `afterEach( async() => {})`
 
 ### Fixed
 - Fixed assertions https://github.com/VadimNastoyashchy/real-test-js/issues/74

--- a/src/core/cli.mjs
+++ b/src/core/cli.mjs
@@ -1,5 +1,5 @@
 import { EOL } from 'os'
-import { ARGS } from '../core/constants.mjs'
+import { ARGS } from './constants.mjs'
 import { applyColor } from '../utils/transform.mjs'
 
 const args = process.argv // get arguments from command line

--- a/src/utils/transform.mjs
+++ b/src/utils/transform.mjs
@@ -20,7 +20,14 @@ export const last = (arr) => arr[arr.length - 1]
 
 export const withoutLast = (arr) => arr.slice(0, -1)
 
-export const executeAll = (fnArray) => fnArray.forEach((fn) => fn())
+export const executeAllAndWait = async (fnArray) => {
+  for (const fn of fnArray) {
+    const result = fn()
+    if (result instanceof Promise) {
+      await Promise.race([result])
+    }
+  }
+}
 
 const ignoredFilePatterns = [
   '/node_modules/',


### PR DESCRIPTION
Based on : https://github.com/VadimNastoyashchy/real-test-js/issues/89

### Added
- Added async support for hooks:
  - `beforeAll( async() => {})`
  - `afterAll( async() => {})`
  - `beforeEach( async() => {})`
  - `afterEach( async() => {})`